### PR TITLE
Update to version 2.7.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function processBlock(blk) {
     @return {Object}
 */
 function getWebsiteAssets() {
-    var version = this.config.get('pluginsConfig.mathjax.version', '2.7.1');
+    var version = this.config.get('pluginsConfig.mathjax.version', '2.7.6');
 
     return {
         assets: "./book",

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var crc = require('crc');
 var exec = require('child_process').exec;
-var mjAPI = require('mathjax-node/lib/mj-single.js');
+var mjAPI = require('mathjax-node/lib/main.js');
 
 var started = false;
 var countMath = 0;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
             "version": {
                 "type": "string",
                 "title": "Version of MathJAX to use for website rendering",
-                "default": "2.7.1"
+                "default": "2.7.6"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gitbook": ">=3.0.0"
     },
     "dependencies": {
-        "mathjax-node": "0.5.2",
+        "mathjax-node": "2.1.1",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gitbook": ">=3.0.0"
     },
     "dependencies": {
-        "mathjax-node": "2.1.1",
+        "mathjax-node": "2.0.0",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },


### PR DESCRIPTION
Mathjax has stopped loading. It is pulling in dependencies from mathjax v3 plugin when I need it to pull in the mathjax 2 api.

This update fixes the gitbook mathjax plugin to use the last mathjax v2.x library (2.7.6) before it moves to v 3 (signficant updates). 

The fix also update the underling mathjax-node dependency to v2.0.0. This is not the latest node version (2.1.1 at time of writing) but it is the last one that supports node 4. As node 4 is a dependency for legacy gitbook support, choosing to keep that one.